### PR TITLE
Fix various issues

### DIFF
--- a/src/commands/definitionToTable.ts
+++ b/src/commands/definitionToTable.ts
@@ -70,14 +70,8 @@ export async function definitionToTable(this: ExtensionContext) {
 
     const docs = getDocumentationCommentAsString(checker, symbol);
 
-    let escapedName = symbol.escapedName;
-
-    if (type.aliasSymbol) {
-      escapedName = type.aliasSymbol.escapedName;
-    }
-
     const defs: Definition = {
-      name: escapedName.toString(),
+      name: checker.typeToString(type),
       props: [],
       docs,
     };

--- a/src/lib/ts-utils.ts
+++ b/src/lib/ts-utils.ts
@@ -20,6 +20,8 @@ import {
   isTypeAliasDeclaration,
   getPositionOfLineAndCharacter,
   TypeAliasDeclaration,
+  InterfaceType,
+  InterfaceTypeWithDeclaredMembers,
 } from "typescript";
 
 interface ProgramAndSourceFile {
@@ -182,5 +184,16 @@ export function getNearestDefinition(
   return getNearestDefinitionFromPosition(
     sourceFile,
     getPositionOfLineAndCharacter(sourceFile, line, character)
+  );
+}
+
+export function isInterfaceTypeWithDeclaredMembers(
+  interfaceType: InterfaceType
+): interfaceType is InterfaceTypeWithDeclaredMembers {
+  return (
+    typeof (interfaceType as InterfaceTypeWithDeclaredMembers)
+      .declaredStringIndexInfo !== "undefined" ||
+    typeof (interfaceType as InterfaceTypeWithDeclaredMembers)
+      .declaredNumberIndexInfo !== "undefined"
   );
 }

--- a/src/test/suite/interface.test.ts
+++ b/src/test/suite/interface.test.ts
@@ -191,7 +191,7 @@ suite("Interfaces", () => {
         await commands.executeCommand(DEFINITION_TO_TABLE_COMMAND);
 
         await assertClipboardEqualDefinition({
-          name: "Test",
+          name: "Test<T, U>",
           props: [
             { name: "key", type: "T" },
             { name: "value", type: "U" },

--- a/src/test/suite/type.test.ts
+++ b/src/test/suite/type.test.ts
@@ -154,7 +154,7 @@ suite("Types", () => {
       await commands.executeCommand(DEFINITION_TO_TABLE_COMMAND);
 
       await assertClipboardEqualDefinition({
-        name: "Test",
+        name: "Test<T>",
         props: [{ name: "a", type: "T" }],
       });
     });

--- a/src/test/suite/type.test.ts
+++ b/src/test/suite/type.test.ts
@@ -147,7 +147,72 @@ suite("Types", () => {
     );
   });
 
-  test("should export a mapped type");
+  test("should export a mapped type mapping over a type", () => {
+    return withTSEditor(
+      `type Test = ToNumber<Test1>;
+    type Test1 = { a: string; b: boolean };
+    type ToNumber<T> = {
+      [key in keyof T]: number
+    }`,
+      async () => {
+        await commands.executeCommand(DEFINITION_TO_TABLE_COMMAND);
+
+        await assertClipboardEqualDefinition({
+          name: "ToNumber<Test1>",
+          props: [
+            { name: "a", type: "number" },
+            { name: "b", type: "number" },
+          ],
+        });
+      }
+    );
+  });
+
+  test("should export a mapped type mapping over an interface", () => {
+    return withTSEditor(
+      `type Test<K extends keyof Test1> = {
+      [key in K]: number;
+    };
+    interface Test1 {
+      a: string;
+      b: number;
+    }`,
+      async () => {
+        await commands.executeCommand(DEFINITION_TO_TABLE_COMMAND);
+
+        await assertClipboardEqualDefinition({
+          name: "ToNumber<Test1>",
+          props: [
+            { name: "a", type: "number" },
+            { name: "b", type: "number" },
+          ],
+        });
+      }
+    );
+  });
+
+  test("should export a mapped type mapping over an interface combined with an intersection", () => {
+    return withTSEditor(
+      `type Test<K extends keyof Test1> = {
+    [key in K]: number;
+  } & { c: string };
+  interface Test1 {
+    a: string;
+    b: number;
+  }`,
+      async () => {
+        await commands.executeCommand(DEFINITION_TO_TABLE_COMMAND);
+
+        await assertClipboardEqualDefinition({
+          name: "Test<K>",
+          props: [
+            { name: "[key in K]", type: "number" },
+            { name: "c", type: "string" },
+          ],
+        });
+      }
+    );
+  });
 
   test("should export a generic type", () => {
     return withTSEditor(`type Test<T> = { a: T }`, async () => {


### PR DESCRIPTION
This pull request fix various issues.

# Types & interfaces exported names

The following type & interface were previously exported with the *incomplete* names `Test1` & `Test2`.

```ts
interface Test1<T, U> {
  key: T; value: U
}

type Test2<T> = {
  a: T
}
```

They are now exported with the `Test1<T, U>` & `Test2<T>` names as expected.

Thanks to the tests, we just had to update our test expectations for this kind of definitions (which would break the tests), update the code and then make the sure the tests are now properly passing for all cases which is the case.

# Mapped types

I also added support for mapped types (and various associated tests). The following types are now properly exported:

```ts
type TestA = ToNumber<Test1>;
type Test1 = { a: string; b: boolean };
type ToNumber<T> = {
  [key in keyof T]: number
}


type TestB<K extends keyof Test2> = {
  [key in K]: number;
};
interface Test2 {
  a: string;
  b: number;
}

type TestC<K extends keyof Test3> = {
  [key in K]: number;
} & { c: string };
interface Test3 {
  a: string;
  b: number;
}
```

A neat thing to note, when exporting the `[key in K]` bit, it's actually not hardcoded which means that having `[prout in K]` would export it properly with `prout`.

# Index signatures

I slightly refactored the index signature support in interfaces so that the `[key: string]` bit is no longer hardcoded which means that having `[prout: string]` would export it properly with `prout`.

Thanks to the existing tests, we just had to update the code and make sure the existing tests were still passing for these cases.