### PR TITLE
Prevent commits to the main branch

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "main" ]; then
+  echo "You can't commit directly to the main branch!"
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "build": "yarn clean && tsc",
     "pretest": "yarn build",
     "test": "node dist/test/runTest.js",
-    "package": "yarn build && vsce package"
+    "package": "yarn build && vsce package",
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@types/glob": "^7.1.4",
@@ -60,7 +61,8 @@
     "@types/vscode": "^1.59.0",
     "mocha": "8.4.0",
     "rimraf": "^3.0.2",
-    "vscode-test": "1.6.1"
+    "vscode-test": "1.6.1",
+    "husky": "^7.0.0"
   },
   "dependencies": {
     "glob": "^7.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,6 +365,11 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+husky@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.2.tgz#21900da0f30199acca43a46c043c4ad84ae88dff"
+  integrity sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"


### PR DESCRIPTION
When using this hook and trying to commit to the main branch, you'll get an error. For example, using VSC you get:

<img width="260" alt="Screenshot 2021-08-31 at 12 02 51" src="https://user-images.githubusercontent.com/494699/131483677-13cc1570-43a7-41fc-9384-5a7e2e7d1d2b.png">

[Husky](https://typicode.github.io/husky/#/) is the one of the easiest & [most used](https://typicode.github.io/husky/#/?id=used-by) tool when it comes to hooks in the npm ecosystem, for example, here is [the `pre-commit` hook used by rollup/rollup](https://github.com/rollup/rollup/blob/81fa9e9812be882e8ca791c0bd4314d23f0d5640/.husky/pre-commit) to lint (only) staged files before a commit.

The added `prepare` npm script automatically setup hooks locally after all the packages are installed and is [the recommended way vs `postinstall`](https://blog.typicode.com/husky-git-hooks-autoinstall/). Following this pattern, you could lint staged files using ESLint before a commit, run tests before a push, etc.